### PR TITLE
README: Correct formatting, and add Maven usage info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-funimage
-========
+# funimage
 
 [![Join the chat at https://gitter.im/funimage/funimage](https://badges.gitter.im/funimage/funimage.svg)](https://gitter.im/funimage/funimage?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
@@ -7,21 +6,20 @@ Functional Image Processing with ImageJ/FIJI
 
 [![Build Status](https://travis-ci.org/funimage/funimage.svg?branch=master)](https://travis-ci.org/funimage/funimage)
 
-=========
+------
 
 Note to functional programming folks, funimage is *destructive* by default. Images are large and take up lots of memory, we try not to duplicate data unless necessary. If you want to do something non-destructively, then you need to explicitly use functions like copy-imp.
 
-========
+------
+## Usage
 
-#Usage within ImageJ:
+### Usage within ImageJ:
 
 Add an update site like you would usually (see http://fiji.sc/List_of_update_sites)   
 
 where the update site is: http://sites.imagej.net/Funimage/  
 
-=========
-
-#Usage within Clojure projects:
+### Usage within Clojure projects:
 
 Add the following to your `project.clj`
 
@@ -29,17 +27,38 @@ Add the following to your `project.clj`
   :repositories [["imagej-releases" "http://maven.imagej.net/content/repositories/releases/"]
                  ["imagej-snapshots" "http://maven.imagej.net/content/repositories/snapshots/"]]
                  
-```                 
-                 
-========                 
+```
 
-Citing:
+### Usage within Maven projects:
 
-Functional Image Processing with ImageJ/FIJI
+Add the following dependency to your `pom.xml`
+
+```
+<dependency>
+	<groupId>funimage</groupId>
+	<artifactId>funimage</artifactId>
+	<version>0.1.99</version>
+</dependency>
+```
+
+And add the following repository to the `pom.xml` as well:
+
+```
+<repository>
+	<id>imagej.public</id>
+	<url>http://maven.imagej.net/content/groups/public</url>
+</repository>
+```
+
+------
+
+## Citation
+
+[Functional Image Processing with ImageJ/FIJI](https://isg.nist.gov/BII_2015/webPages/pages/2015_BII_program/PDFs/Day_3/Session_8/Abstract_Harrington_Kyle.pdf)
 K. Harrington, T. Stiles, L. Venkatraman, C.Prahst, K. Bentley
-Proceedings of Bioimage Informatics, 2015, (accepted).
+Proceedings of Bioimage Informatics, 2015.
 
-=========
+------
 
 License:
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ where the update site is: http://sites.imagej.net/Funimage/
 Add the following to your `project.clj`
 
 ```
-  :repositories [["imagej-releases" "http://maven.imagej.net/content/repositories/releases/"]
-                 ["imagej-snapshots" "http://maven.imagej.net/content/repositories/snapshots/"]]
+  :repositories [["imagej-releases" "https://maven.imagej.net/content/repositories/releases/"]
+                 ["imagej-snapshots" "https://maven.imagej.net/content/repositories/snapshots/"]]
                  
 ```
 
@@ -46,7 +46,7 @@ And add the following repository to the `pom.xml` as well:
 ```
 <repository>
 	<id>imagej.public</id>
-	<url>http://maven.imagej.net/content/groups/public</url>
+	<url>https://maven.imagej.net/content/groups/public</url>
 </repository>
 ```
 

--- a/project.clj
+++ b/project.clj
@@ -24,14 +24,14 @@
                  [sc.fiji/Auto_Threshold "1.16.0"]
                  ]
   :java-source-paths ["java"]
-  :repositories [["imagej" "http://maven.imagej.net/content/groups/hosted/"]
-                 ["imagej-releases" "http://maven.imagej.net/content/repositories/releases/"]
-                 ["ome maven" "http://artifacts.openmicroscopy.org/artifactory/maven/"]
-                 ["imagej-snapshots" "http://maven.imagej.net/content/repositories/snapshots/"]
-                 ["clojars2" {:url "http://clojars.org/repo/"
+  :repositories [["imagej" "https://maven.imagej.net/content/groups/hosted/"]
+                 ["imagej-releases" "https://maven.imagej.net/content/repositories/releases/"]
+                 ["ome maven" "https://artifacts.openmicroscopy.org/artifactory/maven/"]
+                 ["imagej-snapshots" "https://maven.imagej.net/content/repositories/snapshots/"]
+                 ["clojars2" {:url "https://clojars.org/repo/"
                              :username :env/LEIN_USERNAME
                               :password :env/LEIN_PASSWORD}]]
-  :deploy-repositories [["releases" {:url "http://maven.imagej.net/content/repositories/releases"
+  :deploy-repositories [["releases" {:url "https://maven.imagej.net/content/repositories/releases"
                                      ;; Select a GPG private key to use for
                                      ;; signing. (See "How to specify a user
                                      ;; ID" in GPG's manual.) GPG will
@@ -42,7 +42,7 @@
                                      :username :env/CI_DEPLOY_USERNAME
                                      :password :env/CI_DEPLOY_PASSWORD
                                      :sign-releases false}]
-                        ["snapshots" {:url "http://maven.imagej.net/content/repositories/snapshots"
+                        ["snapshots" {:url "https://maven.imagej.net/content/repositories/snapshots"
                                       :username :env/CI_DEPLOY_USERNAME
                                       :password :env/CI_DEPLOY_PASSWORD
                                       :sign-releases false}]]


### PR DESCRIPTION
* corrects formatting such that headlines are correctly recognized as Github-flavoured Markdown
* adds information how to use funimage in Maven projects
* adds link to the proceedings paper